### PR TITLE
Support Expo SDK v33.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/tomLadder/react-native-echarts-wrapper/issues"
   },
   "homepage": "https://github.com/tomLadder/react-native-echarts-wrapper#readme",
-  "dependencies": {
+  "peerDependencies": {
     "prop-types": "^15.7.2",
     "react-native-webview": "^5.7.0"
   },


### PR DESCRIPTION
Use peerDependencies instead of dependencies to make it work with Expo SDK v33.0.0.