### PR TITLE
#add the property to webView to resolve cash on Android platform.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,7 @@ class ECharts extends Component {
           allowUniversalAccessFromFileURLs
           mixedContentMode="always"
           onLoadEnd={this.onLoadEnd}
+          androidHardwareAccelerationDisabled
         />
       </View>
     );


### PR DESCRIPTION
When  using Echarts,  we found that when you jump to a page, you'll have a flashback on Android, but it's normal on iOS. If you add this property to the WebView, you can solve the fallback problem.