### PR TITLE
backgroundColor loading transparent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,7 @@ class ECharts extends Component {
     return (
       <View style={{ flex: 1 }}>
         <WebView
+          style={{ backgroundColor:'transparent'}}
           ref={this.getWebViewRef}
           originWhitelist={["*"]}
           scrollEnabled={false}


### PR DESCRIPTION
If the background is not white, when the graphic is loading it is a white square, so leaving the background color as transparent helps with that.